### PR TITLE
Add pytest anchor link test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### A COMPREHENSIVE COLLECTION OF TECHNICAL ARTICLES AND GUIDES
 
-[📖 About](#-about) • [🤖 AI/ML & Data Science](#-aiml--data-science) • [☁️ Cloud & DevOps](#️-cloud-computing--devops) • [🏗️ Architecture](#️-software-architecture--design) • [💻 Development](#-development--tools)
+[📖 About](#-about) • [🤖 AI/ML & Data Science](#-aiml--data-science) • [☁️ Cloud & DevOps](#️-cloud-computing) • [🏗️ Architecture](#️-software-architecture--design) • [💻 Development](#-development--tools)
 
 [![Blog Categories](https://img.shields.io/badge/Categories-10+-blue)](https://github.com/tapinder/MinimalDevOps-Blog-Collection#-table-of-contents)
 [![Total Articles](https://img.shields.io/badge/Articles-100+-green)](https://github.com/tapinder/MinimalDevOps-Blog-Collection#-table-of-contents)
@@ -210,6 +210,14 @@ Welcome to my collection of technical articles covering various aspects of softw
 - [Author's LinkedIn](https://www.linkedin.com/in/tapinder-singh/)
 - [Website](https://minimaldevops.com/)
 - [Medium Profile](https://medium.com/@minimaldevops)
+
+## ✅ Running Tests
+
+To run the tests use:
+
+```bash
+pytest
+```
 
 ## 📝 License
 

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,32 @@
+import re
+from pathlib import Path
+
+
+def slugify(text: str) -> str:
+    """Simplified slug function similar to GitHub's"""
+    value = text.lower()
+    value = re.sub(r'[^\w\s-]', '', value)
+    value = value.replace(' ', '-')
+    return value
+
+
+def extract_anchor_links(text: str):
+    pattern = re.compile(r'\[[^\]]+\]\(#([^\)]+)\)')
+    return pattern.findall(text)
+
+
+def extract_heading_slugs(text: str):
+    slugs = []
+    for line in text.splitlines():
+        m = re.match(r'^#+\s+(.*)', line)
+        if m:
+            slugs.append(slugify(m.group(1)))
+    return slugs
+
+
+def test_markdown_anchor_links_have_headings():
+    readme = Path('README.md').read_text(encoding='utf-8')
+    anchors = [slugify(a) for a in extract_anchor_links(readme)]
+    heading_slugs = set(extract_heading_slugs(readme))
+    missing = [a for a in anchors if a not in heading_slugs]
+    assert not missing, f"Missing headings for anchors: {missing}"


### PR DESCRIPTION
## Summary
- add a small pytest to check README internal links
- document how to run the tests in README
- fix Cloud & DevOps anchor so tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f2bbc0a88326ab9bb1fcc79fbc01