### PR TITLE
Run tests via Dagger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint with Dagger (self-hosted)
+name: Tests with Dagger (self-hosted)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  dagger-lint:
+  dagger-ci:
     runs-on: self-hosted
 
     steps:
@@ -22,5 +22,5 @@ jobs:
           brew install dagger/tap/dagger
           dagger engine install
 
-      - name: Run lint with Dagger
+      - name: Run tests with Dagger
         run: go run main.go

--- a/main.go
+++ b/main.go
@@ -8,21 +8,23 @@ import (
 func main() {
 	ctx := context.Background()
 	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
 	defer client.Close()
 
 	src := client.Host().Directory(".", dagger.HostDirectoryOpts{
 		Exclude: []string{"node_modules"},
 	})
 
-	ctr := client.Container().
-		From("node:18").
+	tests := client.Container().
+		From("python:3.11").
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
-		WithExec([]string{"npm", "ci"}).
-		WithExec([]string{"npx", "eslint", "."})
+		WithExec([]string{"python", "-m", "pip", "install", "pytest"}).
+		WithExec([]string{"pytest", "-q"})
 
-	_, err = ctr.Stdout(ctx)
-	if err != nil {
+	if _, err = tests.Stdout(ctx); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary
- run Python tests from `main.go`
- remove lint and node steps from Dagger pipeline and GitHub workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852512f4e348326940771e09bef6a82