### PR TITLE
Install dagger before running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,9 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Install Dagger
+        run: curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.10 BIN_DIR=/usr/local/bin sh
+
+
       - name: Run tests with Dagger
         run: go run main.go


### PR DESCRIPTION
## Summary
- setup Dagger CLI before running the Dagger tests in CI

## Testing
- `go run main.go` *(fails: Forbidden while downloading toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68531ee1ae008326b77467ce5c23b598