### PR TITLE
docs: add blockchain terminology article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Welcome to my collection of technical articles covering various aspects of softw
 - [Cloud Governance, Security, and Compliance](https://medium.com/cloud-governance-security-and-compliance-992afee07e7b) ([Friendly URL](https://blog.devops.dev/cloud-governance-security-and-compliance-992afee07e7b?source=friends_link&sk=a479b0a2bfb0bc46ff805ef4c0ee52df))
 - [Implementing gRPC in AWS: Leveraging CDN, Load Balancers, and API Gateway](https://medium.com/implementing-grpc-in-aws-leveraging-cdn-load-balancers-and-api-gateway-best-practices-and-24ab6acdde16) ([Friendly URL](https://minimaldevops.com/implementing-grpc-in-aws-leveraging-cdn-load-balancers-and-api-gateway-best-practices-and-24ab6acdde16?source=friends_link&sk=ff7282e6701f9c0e390bce618af353ae))
 - [BGP: What Every DevOps, Cloud, and XYZ Engineer Should Know](https://medium.com/@minimaldevops/bgp-what-every-devops-cloud-and-xyz-engineer-should-know-198caf462228) ([Friendly URL](https://minimaldevops.com/bgp-what-every-devops-cloud-and-xyz-engineer-should-know-198caf462228?source=friends_link&sk=21b644b232c22c459ea52ecf8076153a))
+- [Blockchain Terminology Explained for DevOps, Cloud, or Kubernetes Engineers](https://medium.com/blockchain-terminology-explained-for-devops-cloud-or-kubernetes-engineers-9b0b309777b3) ([Friendly URL](https://minimaldevops.com/blockchain-terminology-explained-for-devops-cloud-or-kubernetes-engineers-9b0b309777b3?sk=992fb3c8a2d78e955dd06b4604a65b2f))
 
 ## 🏗️ Software Architecture & Design
 


### PR DESCRIPTION
## Summary
- add Blockchain terminology article link under Cloud General

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c69f645c8326bf479080f7390762